### PR TITLE
Improve file permission step for Linux server executable

### DIFF
--- a/.github/workflows/build-sharp.yaml
+++ b/.github/workflows/build-sharp.yaml
@@ -430,7 +430,7 @@ jobs:
       - name: Update File Permissions
         shell: bash
         run: |
-          chmod +x release/SPT/SPT.Server.Linux
+          find release -name "SPT.Server.Linux" -type f -exec chmod +x {} \;
 
       - name: Clone Build Project
         uses: actions/checkout@v4


### PR DESCRIPTION
**Note:**  I'm unable to test the full workflow with the change because of Github secrets. the change has been tested in a local script though.

Replaces the hard-coded file path for the `SPT.Server.Linux` executable & instead searches for it inside the `release` directory.

Potentially helps with further directory structure changes.