### PR TITLE
Include pdb Files in Release

### DIFF
--- a/.github/workflows/build-sharp.yaml
+++ b/.github/workflows/build-sharp.yaml
@@ -231,7 +231,6 @@ jobs:
           name: server-artifact-win-x64
           path: |
             SPT/Build/server-csharp/SPTarkov.Server/bin/${{ needs.prepare.outputs.build_config }}/net9.0/win-x64/publish/
-            !SPT/Build/server-csharp/SPTarkov.Server/bin/${{ needs.prepare.outputs.build_config }}/net9.0/win-x64/publish/**/*.pdb
           compression-level: 0
           retention-days: 1
           overwrite: true
@@ -243,7 +242,6 @@ jobs:
           name: server-artifact-linux-x64
           path: |
             SPT/Build/server-csharp/SPTarkov.Server/bin/${{ needs.prepare.outputs.build_config }}/net9.0/linux-x64/publish/
-            !SPT/Build/server-csharp/SPTarkov.Server/bin/${{ needs.prepare.outputs.build_config }}/net9.0/linux-x64/publish/**/*.pdb
           compression-level: 0
           retention-days: 1
           overwrite: true


### PR DESCRIPTION
Since the server is no longer built as a single file and all files are now in the SPT subdirectory, the PDB files shouldn't cause any file clutter in the game directory. The debug information from pdb files will make it easier to troubleshoot when exceptions occur.
